### PR TITLE
refactor: enable dependants to define these constants

### DIFF
--- a/XPT2046_Bitbang.h
+++ b/XPT2046_Bitbang.h
@@ -4,8 +4,14 @@
 #include "Arduino.h"
 #include <SPIFFS.h>
 
-#define TFT_HEIGHT 320
+
+#ifndef TFT_WIDTH
 #define TFT_WIDTH 240
+#endif
+
+#ifndef TFT_HEIGHT
+#define TFT_HEIGHT 320
+#endif
 
 struct Point {
     int x;


### PR DESCRIPTION
With these changes dependant projects can use build flags to define values for the constants shown below. For example, in platform.io, one can do the following:


````yaml
build_flags = 
  -D TFT_WIDTH=320
  -D TFT_HEIGHT=240
````

without these changes, values passed by parent projects won't be taken into consideration.