### PR TITLE
Add set calibration

### DIFF
--- a/XPT2046_Bitbang.cpp
+++ b/XPT2046_Bitbang.cpp
@@ -94,6 +94,13 @@ void XPT2046_Bitbang::saveCalibration() {
     calFile.close();
 }
 
+void XPT2046_Bitbang::setCalibration(int xMin, int yMin, int xMax, int yMax) {
+    cal.xMin = xMin;
+    cal.yMin = yMin;
+    cal.xMax = xMax;
+    cal.yMax = yMax;
+}
+
 Point XPT2046_Bitbang::getTouch() {
     digitalWrite(_csPin, LOW);
     int x = readSPI(CMD_READ_X);


### PR DESCRIPTION
This allows people who already know calibration values to just set them. It removes the need of calling loadCalibration.



```c++
void init_touch()
{
    Serial.println("Initializing touch");
    touchscreen.begin();
    touchscreen.setCalibration(178, 132, 1869, 1784);
    Serial.println("Touch driver initialized and registered.");
}
```